### PR TITLE
samples: foc_controller add support for nucleo f401re and f411re

### DIFF
--- a/samples/foc_controller/boards/nucleo_f401re.overlay
+++ b/samples/foc_controller/boards/nucleo_f401re.overlay
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2022 Linaro
+ */
+
+ #include <dt-bindings/pwm/pwm.h>
+
+/ {
+	gpio_enable {
+		compatible = "gpio-keys";
+		inverter_enable: button {
+			label = "inverter_enable";
+			gpios = <&gpioc 10 GPIO_ACTIVE_HIGH>,
+                    <&gpioc 11 GPIO_ACTIVE_HIGH>,
+                    <&gpioc 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+ 
+ /* Set PWM that are attached to the IHM07 dev board's power stage */
+ &timers1 {
+     status = "okay";
+ 
+     inverter_pwm: pwm {
+         status = "okay";
+         pinctrl-0 = <&tim1_ch1_pa8 &tim1_ch2_pa9 &tim1_ch3_pa10>; 
+         pinctrl-names = "default";
+     };
+};
+
+&i2c1 {
+	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/samples/foc_controller/boards/nucleo_f411re.overlay
+++ b/samples/foc_controller/boards/nucleo_f411re.overlay
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2022 Linaro
+ */
+
+ #include <dt-bindings/pwm/pwm.h>
+
+/ {
+	gpio_enable {
+		compatible = "gpio-keys";
+		inverter_enable: button {
+			label = "inverter_enable";
+			gpios = <&gpioc 10 GPIO_ACTIVE_HIGH>,
+                    <&gpioc 11 GPIO_ACTIVE_HIGH>,
+                    <&gpioc 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+ 
+ /* Set PWM that are attached to the IHM07 dev board's power stage */
+ &timers1 {
+     status = "okay";
+ 
+     inverter_pwm: pwm {
+         status = "okay";
+         pinctrl-0 = <&tim1_ch1_pa8 &tim1_ch2_pa9 &tim1_ch3_pa10>; 
+         pinctrl-names = "default";
+     };
+};
+
+&i2c1 {
+	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/samples/foc_controller/src/foc_driver.c
+++ b/samples/foc_controller/src/foc_driver.c
@@ -24,9 +24,7 @@
 
 #define ROTOR_DRV_PAYLOAD_SZ      (sizeof(struct foc_controller_payload))
 #define ROTOR_DRV_PAYLOAD_SRC_ID  (2)
-
-/* PWM frequency about 16KHz */
-#define PWM_PERIOD_NSEC 62500
+#define PWM_PERIOD_NSEC 25000
 
 /**
  * @brief Pre-populated measurement header to copy into allocated measurements.


### PR DESCRIPTION
Also increases the PWM speed of this sample to reduce noise and operation of the motor in discontinuous mode. 